### PR TITLE
Configurable ancestry resolution for Gazetteer queries and CLAVIN location resolution.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
             <version>4.9.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.bericotech</groupId>
     <artifactId>clavin</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/src/main/java/com/bericotech/clavin/GeoParser.java
+++ b/src/main/java/com/bericotech/clavin/GeoParser.java
@@ -2,6 +2,7 @@ package com.bericotech.clavin;
 
 import com.bericotech.clavin.extractor.LocationExtractor;
 import com.bericotech.clavin.extractor.LocationOccurrence;
+import com.bericotech.clavin.gazetteer.query.AncestryMode;
 import com.bericotech.clavin.gazetteer.query.Gazetteer;
 import com.bericotech.clavin.resolver.ClavinLocationResolver;
 import com.bericotech.clavin.resolver.ResolvedLocation;
@@ -93,20 +94,40 @@ public class GeoParser {
      * @throws Exception
      */
     public List<ResolvedLocation> parse(String inputText) throws Exception {
+        return parse(inputText, ClavinLocationResolver.DEFAULT_ANCESTRY_MODE);
+    }
+
+    /**
+     * Takes an unstructured text document (as a String), extracts the
+     * location names contained therein, and resolves them into
+     * geographic entities representing the best match for those
+     * location names.
+     *
+     * @param inputText     unstructured text to be processed
+     * @param ancestryMode  the ancestry load mode
+     * @return              list of geo entities resolved from text
+     * @throws Exception
+     */
+    public List<ResolvedLocation> parse(String inputText, AncestryMode ancestryMode) throws Exception {
 
         logger.trace("input: {}", inputText);
 
+        long extractStart = System.currentTimeMillis();
         // first, extract location names from the text
         List<LocationOccurrence> locationNames = extractor.extractLocationNames(inputText);
+        long extractEnd = System.currentTimeMillis();
 
         logger.trace("extracted: {}", locationNames);
 
+        long resolveStart = System.currentTimeMillis();
         // then, resolve the extracted location names against a
         // gazetteer to produce geographic entities representing the
         // locations mentioned in the original text
-        List<ResolvedLocation> resolvedLocations = resolver.resolveLocations(locationNames, maxHitDepth, maxContextWindow, fuzzy);
+        List<ResolvedLocation> resolvedLocations = resolver.resolveLocations(locationNames, maxHitDepth, maxContextWindow, fuzzy, ancestryMode);
+        long resolveEnd = System.currentTimeMillis();
 
         logger.trace("resolved: {}", resolvedLocations);
+        logger.debug("Extractor Time: {} ms, Resolver Time: {} ms", extractEnd - extractStart, resolveEnd - resolveStart);
 
         return resolvedLocations;
     }

--- a/src/main/java/com/bericotech/clavin/gazetteer/BasicGeoName.java
+++ b/src/main/java/com/bericotech/clavin/gazetteer/BasicGeoName.java
@@ -1,0 +1,777 @@
+package com.bericotech.clavin.gazetteer;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*#####################################################################
+ *
+ * CLAVIN (Cartographic Location And Vicinity INdexer)
+ * ---------------------------------------------------
+ *
+ * Copyright (C) 2012-2013 Berico Technologies
+ * http://clavin.bericotechnologies.com
+ *
+ * ====================================================================
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * ====================================================================
+ *
+ * BasicGeoName.java
+ *
+ *###################################################################*/
+
+/**
+ * Data-rich representation of a named location, based on entries in
+ * the GeoNames gazetteer.
+ *
+ * TODO: link administrative subdivision code fields to the GeoName
+ *       records they reference
+ *
+ */
+public class BasicGeoName implements GeoName {
+    /**
+     * The logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(BasicGeoName.class);
+
+    /**
+     * The regex used to extract the administrative division level for A:ADM[1-4]H? records
+     */
+    private static final Pattern ADM_LEVEL_REGEX = Pattern.compile("^ADM(\\d)H?$");
+
+    /**
+     * The set of top-level feature codes.
+     */
+    private static final Set<FeatureCode> TOP_LEVEL_FEATURES = EnumSet.of(
+            FeatureCode.PCL,
+            FeatureCode.PCLD,
+            FeatureCode.PCLF,
+            FeatureCode.PCLI,
+            FeatureCode.PCLIX,
+            FeatureCode.PCLS,
+            FeatureCode.TERRI
+    );
+
+    /**
+     * The set of FeatureCodes that are valid administrative ancestors.
+     */
+    private static final Set<FeatureCode> VALID_ADMIN_ANCESTORS = EnumSet.of(
+            FeatureCode.ADM1,
+            FeatureCode.ADM2,
+            FeatureCode.ADM3,
+            FeatureCode.ADM4,
+            FeatureCode.PCL,
+            FeatureCode.PCLD,
+            FeatureCode.PCLF,
+            FeatureCode.PCLI,
+            FeatureCode.PCLIX,
+            FeatureCode.PCLS,
+            FeatureCode.TERRI
+    );
+
+    // id of record in geonames database
+    private final int geonameID;
+
+    // name of geographical point (utf8)
+    private final String name;
+
+    // name of geographical point in plain ascii characters
+    private final String asciiName;
+
+    // list of alternate names for location
+    private final List<String> alternateNames;
+
+    // the preferred name of this GeoName
+    private final String preferredName;
+
+    // latitude in decimal degrees
+    private final double latitude;
+
+    // longitude in decimal degrees
+    private final double longitude;
+
+    // major feature category
+    // (see http://www.geonames.org/export/codes.html)
+    private final FeatureClass featureClass;
+
+    // http://www.geonames.org/export/codes.html
+    private final FeatureCode featureCode;
+
+    // ISO-3166 2-letter country code
+    private final CountryCode primaryCountryCode;
+
+    // associated name with country code
+    @Override
+    public String getPrimaryCountryName(){
+        return  primaryCountryCode.name;
+    }
+
+    // list of alternate ISO-3166 2-letter country codes
+    private final List<CountryCode> alternateCountryCodes;
+
+    /*  TODO: refactor the 4 fields below to link to the GeoName
+     *        object that they refer to
+     */
+
+    // Mostly FIPS codes. ISO codes are used for US, CH, BE and ME. UK
+    // and Greece are using an additional level between country and
+    // FIPS code.
+    private final String admin1Code;
+
+    // code for the second administrative division
+    // (e.g., a county in the US)
+    private final String admin2Code;
+
+    // code for third level administrative division
+    private final String admin3Code;
+
+    // code for fourth level administrative division
+    private final String admin4Code;
+
+    // total number of inhabitants
+    private final long population;
+
+    // in meters
+    private final int elevation;
+
+    // digital elevation model, srtm3 or gtopo30, average elevation of
+    // 3''x3'' (ca 90mx90m) or 30''x30'' (ca 900mx900m) area in meters,
+    // integer. srtm processed by cgiar/ciat.
+    private final int digitalElevationModel;
+
+    // timezone for geographical point
+    private final TimeZone timezone;
+
+    // date of last modification in GeoNames database
+    private final Date modificationDate;
+
+    // the GeoName ID of the parent of this GeoName
+    private Integer parentId;
+
+    // the parent of this GeoName
+    private GeoName parent;
+
+    // the gazetteer record this GeoName was parsed from
+    private String gazetteerRecord;
+
+    /**
+     * Sole constructor for {@link BasicGeoName} class.
+     *
+     * Encapsulates a gazetteer record from the GeoNames database.
+     *
+     * @param geonameID                 unique identifier
+     * @param name                      name of this location
+     * @param asciiName                 plain text version of name
+     * @param alternateNames            list of alternate names, if any
+     * @param preferredName             the preferred name, if known
+     * @param latitude                  lat coord
+     * @param longitude                 lon coord
+     * @param featureClass              general type of feature (e.g., "Populated place")
+     * @param featureCode               specific type of feature (e.g., "capital of a political entity")
+     * @param primaryCountryCode        ISO country code
+     * @param alternateCountryCodes     list of alternate country codes, if any (i.e., disputed territories)
+     * @param admin1Code                FIPS code for first-level administrative subdivision (e.g., state or province)
+     * @param admin2Code                second-level administrative subdivision (e.g., county)
+     * @param admin3Code                third-level administrative subdivision
+     * @param admin4Code                fourth-level administrative subdivision
+     * @param population                number of inhabitants
+     * @param elevation                 elevation in meters
+     * @param digitalElevationModel     another way to measure elevation
+     * @param timezone                  timezone for this location
+     * @param modificationDate          date of last modification for the GeoNames record
+     * @param gazetteerRecord           the gazetteer record
+     */
+    public BasicGeoName(
+            int geonameID,
+            String name,
+            String asciiName,
+            List<String> alternateNames,
+            String preferredName,
+            Double latitude,
+            Double longitude,
+            FeatureClass featureClass,
+            FeatureCode featureCode,
+            CountryCode primaryCountryCode,
+            List<CountryCode> alternateCountryCodes,
+            String admin1Code,
+            String admin2Code,
+            String admin3Code,
+            String admin4Code,
+            Long population,
+            Integer elevation,
+            Integer digitalElevationModel,
+            TimeZone timezone,
+            Date modificationDate,
+            String gazetteerRecord) {
+        this.geonameID = geonameID;
+        this.name = name;
+        this.asciiName = asciiName;
+        if (alternateNames != null) {
+            // defensive copy
+            this.alternateNames = Collections.unmodifiableList(new ArrayList<String>(alternateNames));
+        } else {
+            // ensure this is never null
+            this.alternateNames = Collections.EMPTY_LIST;
+        }
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.primaryCountryCode = primaryCountryCode;
+        String pccName = primaryCountryCode != null ? primaryCountryCode.name : "";
+        if (alternateCountryCodes != null) {
+            // defensive copy
+            this.alternateCountryCodes = Collections.unmodifiableList(new ArrayList<CountryCode>(alternateCountryCodes));
+        } else {
+            // ensure this is never null
+            this.alternateCountryCodes = Collections.EMPTY_LIST;
+        }
+        this.featureClass = featureClass;
+        // configure the feature code so top-level territories are distinguishable
+        if (featureCode == FeatureCode.TERR) {
+            boolean topLevel = (this.name != null && !this.name.isEmpty() && this.name.equals(pccName)) ||
+                    (this.asciiName != null && !this.asciiName.isEmpty() && this.asciiName.equals(pccName)) ||
+                    this.alternateNames.contains(pccName);
+            this.featureCode = topLevel ? FeatureCode.TERRI : FeatureCode.TERR;
+        } else {
+            this.featureCode = featureCode;
+        }
+        // if this is a top level division, use the primary country name as the preferred name; otherwise
+        // use the name provided or null
+        boolean usePcc = TOP_LEVEL_FEATURES.contains(featureCode) && !pccName.isEmpty() &&
+                ((this.name != null && !this.name.isEmpty() && this.name.equals(pccName)) ||
+                (this.asciiName != null && !this.asciiName.isEmpty() && this.asciiName.equals(pccName)) ||
+                this.alternateNames.contains(pccName));
+        if (usePcc) {
+            this.preferredName = pccName;
+        } else {
+            this.preferredName = preferredName != null && !preferredName.trim().isEmpty() ? preferredName.trim() : null;
+        }
+
+        this.admin1Code = admin1Code;
+        this.admin2Code = admin2Code;
+        this.admin3Code = admin3Code;
+        this.admin4Code = admin4Code;
+        this.population = population;
+        this.elevation = elevation;
+        this.digitalElevationModel = digitalElevationModel;
+        this.timezone = timezone != null ? (TimeZone) timezone.clone() : null;
+        this.modificationDate = modificationDate != null ? new Date(modificationDate.getTime()) : null;
+        this.gazetteerRecord = gazetteerRecord;
+    }
+
+
+    /**
+     * Builds a {@link BasicGeoName} object based on a single gazetteer
+     * record in the GeoNames geographical database.
+     *
+     * @param inputLine     single line of tab-delimited text representing one record from the GeoNames gazetteer
+     * @return              new GeoName object
+     */
+    public static GeoName parseFromGeoNamesRecord(String inputLine) {
+        return parseFromGeoNamesRecord(inputLine, null);
+    }
+
+    /**
+     * Builds a {@link BasicGeoName} object based on a single gazetteer
+     * record in the GeoNames geographical database.
+     *
+     * @param inputLine     single line of tab-delimited text representing one record from the GeoNames gazetteer
+     * @param preferredName the preferred name of this GeoName as indicated by the GeoNames alternate names table
+     * @return              new GeoName object
+     */
+    public static GeoName parseFromGeoNamesRecord(final String inputLine, final String preferredName) {
+        String[] ancestry = inputLine.split("\n");
+        GeoName geoName = parseGeoName(ancestry[0], preferredName);
+        // if more records exist, assume they are the ancestory of the target GeoName
+        if (ancestry.length > 1) {
+            GeoName current = geoName;
+            for (int idx = 1; idx < ancestry.length; idx++) {
+                GeoName parent = parseGeoName(ancestry[idx], null);
+                if (!current.setParent(parent)) {
+                    LOG.error("Invalid ancestry path for GeoName [{}]: {}", geoName, inputLine.replaceAll("\n", " |@| "));
+                    break;
+                }
+                current = parent;
+            }
+        }
+        return geoName;
+    }
+
+    private static GeoName parseGeoName(final String inputLine, final String preferredName) {
+        // GeoNames gazetteer entries are tab-delimited
+        String[] tokens = inputLine.split("\t");
+
+        // initialize each field with the corresponding token
+        int geonameID = Integer.parseInt(tokens[0]);
+        String name = tokens[1];
+        String asciiName = tokens[2];
+
+        List<String> alternateNames;
+        if (tokens[3].length() > 0) {
+            // better to pass empty array than array containing empty String ""
+            alternateNames = Arrays.asList(tokens[3].split(","));
+        } else alternateNames = new ArrayList<String>();
+
+        double latitude;
+        try {
+            latitude = Double.parseDouble(tokens[4]);
+        } catch (NumberFormatException e) {
+            latitude = OUT_OF_BOUNDS;
+        }
+
+        double longitude;
+        try {
+            longitude = Double.parseDouble(tokens[5]);
+        } catch (NumberFormatException e) {
+            longitude = OUT_OF_BOUNDS;
+        }
+
+        FeatureClass featureClass;
+        if (tokens[6].length() > 0) {
+            featureClass = FeatureClass.valueOf(tokens[6]);
+        } else featureClass = FeatureClass.NULL; // not available
+
+        FeatureCode featureCode;
+        if (tokens[7].length() > 0) {
+            featureCode = FeatureCode.valueOf(tokens[7]);
+        } else featureCode = FeatureCode.NULL; // not available
+
+        CountryCode primaryCountryCode;
+        if (tokens[8].length() > 0) {
+            primaryCountryCode = CountryCode.valueOf(tokens[8]);
+        } else primaryCountryCode = CountryCode.NULL; // No Man's Land
+
+        List<CountryCode> alternateCountryCodes = new ArrayList<CountryCode>();
+        if (tokens[9].length() > 0) {
+            // don't pass list only containing empty String ""
+            for (String code : tokens[9].split(",")) {
+                if (code.length() > 0) // check for malformed data
+                    alternateCountryCodes.add(CountryCode.valueOf(code));
+            }
+        }
+
+        String admin1Code = tokens[10];
+        String admin2Code = tokens[11];
+
+        String admin3Code;
+        String admin4Code;
+        long population;
+        int elevation;
+        int digitalElevationModel;
+        TimeZone timezone;
+        Date modificationDate;
+
+        // check for dirty data...
+        if (tokens.length < 19) {
+            // GeoNames record format is corrupted, don't trust any
+            // data after this point
+            admin3Code = "";
+            admin4Code = "";
+            population = OUT_OF_BOUNDS;
+            elevation = OUT_OF_BOUNDS;
+            digitalElevationModel = OUT_OF_BOUNDS;
+            timezone = null;
+            modificationDate = new Date(0);
+        } else { // everything looks ok, soldiering on...
+            admin3Code = tokens[12];
+            admin4Code = tokens[13];
+            try {
+                population = Long.parseLong(tokens[14]);
+            } catch (NumberFormatException e) {
+                population = OUT_OF_BOUNDS;
+            }
+            try {
+                elevation = Integer.parseInt(tokens[15]);
+            } catch (NumberFormatException e) {
+                elevation = OUT_OF_BOUNDS;
+            }
+            try {
+                digitalElevationModel = Integer.parseInt(tokens[16]);
+            } catch (NumberFormatException e) {
+                digitalElevationModel = OUT_OF_BOUNDS;
+            }
+            timezone = TimeZone.getTimeZone(tokens[17]);
+            try {
+                modificationDate = new SimpleDateFormat("yyyy-MM-dd").parse(tokens[18]);
+            } catch (ParseException e) {
+                modificationDate = new Date(0);
+            }
+        }
+
+        return new BasicGeoName(geonameID, name, asciiName, alternateNames, preferredName,
+                latitude, longitude, featureClass, featureCode,
+                primaryCountryCode, alternateCountryCodes, admin1Code,
+                admin2Code, admin3Code, admin4Code, population,
+                elevation, digitalElevationModel, timezone,
+                modificationDate, inputLine);
+    }
+
+    private static int getAdminLevel(final FeatureClass fClass, final FeatureCode fCode) {
+        return getAdminLevel(fClass, fCode, null, null, null);
+    }
+
+    private static int getAdminLevel(final FeatureClass fClass, final FeatureCode fCode, final String geoname, final List<String> altNames, final String countryName) {
+        int admLevel = Integer.MAX_VALUE;
+        if (fClass == FeatureClass.A) {
+            if (fCode == null) {
+                admLevel = -1;
+            } else if (fCode == FeatureCode.TERR) {
+                admLevel = 1;
+            } else if (fCode == FeatureCode.PRSH) {
+                admLevel = 1;
+            } else if (TOP_LEVEL_FEATURES.contains(fCode)) {
+                admLevel = 0;
+            } else {
+                Matcher matcher = ADM_LEVEL_REGEX.matcher(fCode.name());
+                if (matcher.matches()) {
+                    admLevel = Integer.parseInt(matcher.group(1));
+                }
+            }
+        }
+        return admLevel;
+    }
+
+    /**
+     * For pretty-printing.
+     *
+     */
+    @Override
+    public String toString() {
+        return getPreferredName() + " (" + getPrimaryCountryName() + ", " + admin1Code + ")" + " [pop: " + population + "] <" + geonameID + ">";
+    }
+
+    @Override
+    public String getParentAncestryKey() {
+        String key = buildAncestryKey(FeatureCode.ADM4, false);
+        // return null if the key is empty; that means we are a top-level administrative component
+        return !key.isEmpty() ? key : null;
+    }
+
+    @Override
+    public String getAncestryKey() {
+        boolean hasKey = featureClass == FeatureClass.A && VALID_ADMIN_ANCESTORS.contains(featureCode);
+        if (hasKey) {
+            String myCode;
+            switch (featureCode) {
+                case ADM1:
+                    myCode = admin1Code;
+                    break;
+                case ADM2:
+                    myCode = admin2Code;
+                    break;
+                case ADM3:
+                    myCode = admin3Code;
+                    break;
+                case ADM4:
+                    myCode = admin4Code;
+                    break;
+                case PCL:
+                case PCLD:
+                case PCLF:
+                case PCLI:
+                case PCLIX:
+                case PCLS:
+                case TERRI:
+                    myCode = primaryCountryCode != null ? primaryCountryCode.name() : null;
+                    break;
+                default:
+                    myCode = null;
+                    break;
+            }
+            hasKey = myCode != null && !myCode.trim().isEmpty();
+        }
+        String key = (hasKey ? buildAncestryKey(FeatureCode.ADM4, true) : "").trim();
+        return !key.isEmpty() ? key : null;
+    }
+
+    @Override
+    public boolean isTopLevelAdminDivision() {
+        return TOP_LEVEL_FEATURES.contains(featureCode);
+    }
+
+    @Override
+    public boolean isTopLevelTerritory() {
+        return featureCode == FeatureCode.TERRI;
+    }
+
+    /**
+     * Recursively builds the ancestry key for this GeoName, optionally including the
+     * key for this GeoName's administrative division if requested and applicable. See
+     * {@link BasicGeoName#getAncestryKey()} for a description of the ancestry key. Only
+     * divisions that have a non-empty code set in this GeoName will be included in the
+     * key.
+     * @param level the administrative division at the end of the key (e.g. ADM2 to build
+     *              the key COUNTRY.ADM1.ADM2)
+     * @param includeSelf <code>true</code> to include this GeoName's code in the key
+     * @return the generated ancestry key
+     */
+    private String buildAncestryKey(final FeatureCode level, final boolean includeSelf) {
+        // if we have reached the root level, stop
+        if (level == null) {
+            return "";
+        }
+
+        String keyPart;
+        FeatureCode nextLevel;
+        switch (level) {
+            case ADM4:
+                keyPart = admin4Code;
+                nextLevel = FeatureCode.ADM3;
+                break;
+            case ADM3:
+                keyPart = admin3Code;
+                nextLevel = FeatureCode.ADM2;
+                break;
+            case ADM2:
+                keyPart = admin2Code;
+                nextLevel = FeatureCode.ADM1;
+                break;
+            case ADM1:
+                // territories will be considered level 1 if they have the same country code as their
+                // parent but cannot contain descendants so there should be no keypart for this level;
+                // all parishes are considered to be direct descendants of their containing country with
+                // no descendants; they should not have a key part at this level
+                keyPart = featureCode != FeatureCode.TERR && featureCode != FeatureCode.PRSH ? admin1Code : "";
+                nextLevel = FeatureCode.PCL;
+                break;
+            case PCL:
+                keyPart = primaryCountryCode != null && primaryCountryCode != CountryCode.NULL ? primaryCountryCode.name() : "";
+                nextLevel = null;
+                break;
+            default:
+                throw new IllegalArgumentException("Level must be one of [PCL, ADM1, ADM2, ADM3, ADM4]");
+        }
+        keyPart = keyPart.trim();
+        if (nextLevel != null && !keyPart.isEmpty()) {
+            keyPart = String.format(".%s", keyPart);
+        }
+        int keyLevel = getAdminLevel(FeatureClass.A, level);
+        int nameLevel = getAdminLevel(featureClass, featureCode, name, alternateNames, primaryCountryCode.name);
+
+        // if the requested key part is a larger administrative division than the level of the
+        // geoname or, if we are including the geoname's key part and it is the requested part,
+        // include it in the ancestry key (if not blank); otherwise, move to the next level
+        String qualifiedKey = (nameLevel > keyLevel || (includeSelf && keyLevel == nameLevel)) && !keyPart.isEmpty() ?
+                String.format("%s%s", buildAncestryKey(nextLevel, includeSelf), keyPart) :
+                buildAncestryKey(nextLevel, includeSelf);
+        // if any part of the key is missing once a lower-level component has been specified, we cannot
+        // resolve the ancestry path and an empty string should be returned.
+        if (qualifiedKey.startsWith(".") || qualifiedKey.contains("..") || qualifiedKey.endsWith(".")) {
+            qualifiedKey = "";
+        }
+        return qualifiedKey;
+    }
+
+    @Override
+    public boolean isDescendantOf(final GeoName geoname) {
+        boolean descended = false;
+        if (geoname != null) {
+            GeoName test;
+            // empty for loop exits when parent is found or top level is reached
+            for (test = this; test != null && !test.equals(geoname); test = test.getParent());
+            descended = test != null;
+        }
+        return descended;
+    }
+
+    @Override
+    public boolean isAncestorOf(final GeoName geoname) {
+        return geoname != null && geoname.isDescendantOf(this);
+    }
+
+    @Override
+    public GeoName getParent() {
+        return parent;
+    }
+
+    @Override
+    public boolean setParent(final GeoName prnt) {
+        String myParentKey = this.getParentAncestryKey();
+        String parentKey = prnt != null ? prnt.getAncestryKey() : null;
+        boolean parentSet = false;
+        if (prnt != null) {
+            if (prnt.getFeatureClass() != FeatureClass.A || !VALID_ADMIN_ANCESTORS.contains(prnt.getFeatureCode())) {
+                LOG.error(String.format("Invalid administrative parent type [%s:%s] specified for GeoName [%s]; Parent [%s]",
+                        prnt.getFeatureClass(), prnt.getFeatureCode(), this, prnt));
+            } else if (myParentKey != null && parentKey != null && !myParentKey.startsWith(parentKey)) {
+                LOG.error(String.format("Parent ancestry key [%s] does not match the expected key [%s] for GeoName [%s]; Parent [%s]",
+                        parentKey, myParentKey, this, prnt));
+            } else if (this.equals(prnt)) {
+                LOG.warn("Attempted to set parent to self: {}", prnt);
+            } else {
+                this.parent = prnt;
+                parentSet = true;
+            }
+        }
+        return parentSet;
+    }
+
+    @Override
+    public Integer getParentId() {
+        return parent != null ? parent.getGeonameID() : null;
+    }
+
+    @Override
+    public boolean isAncestryResolved() {
+        // this GeoName is considered resolved if it is a top level administrative division,
+        // it is unresolvable, or all parents up to a top-level element have been configured
+        return getAdminLevel(featureClass, featureCode, name, alternateNames, primaryCountryCode.name) <= 0 ||
+                getParentAncestryKey() == null || (parent != null && parent.isAncestryResolved());
+    }
+
+    @Override
+    public int getGeonameID() {
+        return geonameID;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getAsciiName() {
+        return asciiName;
+    }
+
+    @Override
+    public List<String> getAlternateNames() {
+        return alternateNames;
+    }
+
+    @Override
+    public String getPreferredName() {
+        return preferredName != null ? preferredName : name;
+    }
+
+    @Override
+    public double getLatitude() {
+        return latitude;
+    }
+
+    @Override
+    public double getLongitude() {
+        return longitude;
+    }
+
+    @Override
+    public FeatureClass getFeatureClass() {
+        return featureClass;
+    }
+
+    @Override
+    public FeatureCode getFeatureCode() {
+        return featureCode;
+    }
+
+    @Override
+    public CountryCode getPrimaryCountryCode() {
+        return primaryCountryCode;
+    }
+
+    @Override
+    public List<CountryCode> getAlternateCountryCodes() {
+        return alternateCountryCodes;
+    }
+
+    @Override
+    public String getAdmin1Code() {
+        return admin1Code;
+    }
+
+    @Override
+    public String getAdmin2Code() {
+        return admin2Code;
+    }
+
+    @Override
+    public String getAdmin3Code() {
+        return admin3Code;
+    }
+
+    @Override
+    public String getAdmin4Code() {
+        return admin4Code;
+    }
+
+    @Override
+    public long getPopulation() {
+        return population;
+    }
+
+    @Override
+    public int getElevation() {
+        return elevation;
+    }
+
+    @Override
+    public int getDigitalElevationModel() {
+        return digitalElevationModel;
+    }
+
+    @Override
+    public TimeZone getTimezone() {
+        // defensive copy
+        return timezone != null ? (TimeZone) timezone.clone() : null;
+    }
+
+    @Override
+    public Date getModificationDate() {
+        // defensive copy
+        return modificationDate != null ? new Date(modificationDate.getTime()) : null;
+    }
+
+    @Override
+    public String getGazetteerRecord() {
+        return gazetteerRecord;
+    }
+
+    @Override
+    public String getGazetteerRecordWithAncestry() {
+        return parent != null ? String.format("%s\n%s", gazetteerRecord, parent.getGazetteerRecordWithAncestry()) : gazetteerRecord;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 83 * hash + this.geonameID;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final BasicGeoName other = (BasicGeoName) obj;
+        if (this.geonameID != other.geonameID) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/bericotech/clavin/gazetteer/CountryCode.java
+++ b/src/main/java/com/bericotech/clavin/gazetteer/CountryCode.java
@@ -1,31 +1,31 @@
 package com.bericotech.clavin.gazetteer;
 
 /*#####################################################################
- * 
+ *
  * CLAVIN (Cartographic Location And Vicinity INdexer)
  * ---------------------------------------------------
- * 
+ *
  * Copyright (C) 2012-2013 Berico Technologies
  * http://clavin.bericotechnologies.com
- * 
+ *
  * ====================================================================
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
  * implied. See the License for the specific language governing
  * permissions and limitations under the License.
- * 
+ *
  * ====================================================================
- * 
+ *
  * CountryCode.java
- * 
+ *
  *###################################################################*/
 
 /**
@@ -285,19 +285,19 @@ public enum CountryCode {
     ZW("Zimbabwe", 878675),
     CS("Serbia and Montenegro", GeoName.OUT_OF_BOUNDS), // no longer exists
     AN("Netherlands Antilles", GeoName.OUT_OF_BOUNDS), // no longer exists
-    
+
     // manually added for locations not assigned to a specific country
     NULL("No Man's Land", GeoName.OUT_OF_BOUNDS);
-    
+
     // country name
     public final String name;
-    
+
     // unique identifier
     public final int geonameID;
-    
+
     /**
      * Constructor for {@link CountryCode} enum type.
-     * 
+     *
      * @param name          country name
      * @param geonameID     unique identifier
      */
@@ -305,5 +305,5 @@ public enum CountryCode {
         this.name = name;
         this.geonameID = geonameID;
     }
-    
+
 }

--- a/src/main/java/com/bericotech/clavin/gazetteer/GeoName.java
+++ b/src/main/java/com/bericotech/clavin/gazetteer/GeoName.java
@@ -1,20 +1,3 @@
-package com.bericotech.clavin.gazetteer;
-
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /*#####################################################################
  *
  * CLAVIN (Cartographic Location And Vicinity INdexer)
@@ -43,6 +26,12 @@ import org.slf4j.LoggerFactory;
  *
  *###################################################################*/
 
+package com.bericotech.clavin.gazetteer;
+
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
 /**
  * Data-rich representation of a named location, based on entries in
  * the GeoNames gazetteer.
@@ -51,421 +40,23 @@ import org.slf4j.LoggerFactory;
  *       records they reference
  *
  */
-public class GeoName {
+public interface GeoName {
     /**
-     * The logger.
+     * sentinel value used in place of null when numeric value in
+     * GeoNames record is not provided (see: geonameID, latitude,
+     * longitude, population, elevation, digitalElevationModel)
      */
-    private static final Logger LOG = LoggerFactory.getLogger(GeoName.class);
-
-    /**
-     * The regex used to extract the administrative division level for A:ADM[1-4]H? records
-     */
-    private static final Pattern ADM_LEVEL_REGEX = Pattern.compile("^ADM(\\d)H?$");
+    int OUT_OF_BOUNDS = -9999999;
 
     /**
-     * The set of top-level feature codes.
+     * Get the name of the country associated with the primary country code.
+     * @return the name of the primary country
      */
-    private static final Set<FeatureCode> TOP_LEVEL_FEATURES = EnumSet.of(
-            FeatureCode.PCL,
-            FeatureCode.PCLD,
-            FeatureCode.PCLF,
-            FeatureCode.PCLI,
-            FeatureCode.PCLIX,
-            FeatureCode.PCLS,
-            FeatureCode.TERRI
-    );
-
-    /**
-     * The set of FeatureCodes that are valid administrative ancestors.
-     */
-    private static final Set<FeatureCode> VALID_ADMIN_ANCESTORS = EnumSet.of(
-            FeatureCode.ADM1,
-            FeatureCode.ADM2,
-            FeatureCode.ADM3,
-            FeatureCode.ADM4,
-            FeatureCode.PCL,
-            FeatureCode.PCLD,
-            FeatureCode.PCLF,
-            FeatureCode.PCLI,
-            FeatureCode.PCLIX,
-            FeatureCode.PCLS,
-            FeatureCode.TERRI
-    );
-
-    // id of record in geonames database
-    private final int geonameID;
-
-    // name of geographical point (utf8)
-    private final String name;
-
-    // name of geographical point in plain ascii characters
-    private final String asciiName;
-
-    // list of alternate names for location
-    private final List<String> alternateNames;
-
-    // the preferred name of this GeoName
-    private final String preferredName;
-
-    // latitude in decimal degrees
-    private final double latitude;
-
-    // longitude in decimal degrees
-    private final double longitude;
-
-    // major feature category
-    // (see http://www.geonames.org/export/codes.html)
-    private final FeatureClass featureClass;
-
-    // http://www.geonames.org/export/codes.html
-    private final FeatureCode featureCode;
-
-    // ISO-3166 2-letter country code
-    private final CountryCode primaryCountryCode;
-
-    // associated name with country code
-    public String getPrimaryCountryName(){
-        return  primaryCountryCode.name;
-    }
-
-    // list of alternate ISO-3166 2-letter country codes
-    private final List<CountryCode> alternateCountryCodes;
-
-    /*  TODO: refactor the 4 fields below to link to the GeoName
-     *        object that they refer to
-     */
-
-    // Mostly FIPS codes. ISO codes are used for US, CH, BE and ME. UK
-    // and Greece are using an additional level between country and
-    // FIPS code.
-    private final String admin1Code;
-
-    // code for the second administrative division
-    // (e.g., a county in the US)
-    private final String admin2Code;
-
-    // code for third level administrative division
-    private final String admin3Code;
-
-    // code for fourth level administrative division
-    private final String admin4Code;
-
-    // total number of inhabitants
-    private final long population;
-
-    // in meters
-    private final int elevation;
-
-    // digital elevation model, srtm3 or gtopo30, average elevation of
-    // 3''x3'' (ca 90mx90m) or 30''x30'' (ca 900mx900m) area in meters,
-    // integer. srtm processed by cgiar/ciat.
-    private final int digitalElevationModel;
-
-    // timezone for geographical point
-    private final TimeZone timezone;
-
-    // date of last modification in GeoNames database
-    private final Date modificationDate;
-
-    // the parent of this GeoName
-    private GeoName parent;
-
-    // the gazetteer record this GeoName was parsed from
-    private String gazetteerRecord;
-
-    // sentinel value used in place of null when numeric value in
-    // GeoNames record is not provided (see: geonameID, latitude,
-    // longitude, population, elevation, digitalElevationModel)
-    public static final int OUT_OF_BOUNDS = -9999999;
-
-    /**
-     * Sole constructor for {@link GeoName} class.
-     *
-     * Encapsulates a gazetteer record from the GeoNames database.
-     *
-     * @param geonameID                 unique identifier
-     * @param name                      name of this location
-     * @param asciiName                 plain text version of name
-     * @param alternateNames            list of alternate names, if any
-     * @param preferredName             the preferred name, if known
-     * @param latitude                  lat coord
-     * @param longitude                 lon coord
-     * @param featureClass              general type of feature (e.g., "Populated place")
-     * @param featureCode               specific type of feature (e.g., "capital of a political entity")
-     * @param primaryCountryCode        ISO country code
-     * @param alternateCountryCodes     list of alternate country codes, if any (i.e., disputed territories)
-     * @param admin1Code                FIPS code for first-level administrative subdivision (e.g., state or province)
-     * @param admin2Code                second-level administrative subdivision (e.g., county)
-     * @param admin3Code                third-level administrative subdivision
-     * @param admin4Code                fourth-level administrative subdivision
-     * @param population                number of inhabitants
-     * @param elevation                 elevation in meters
-     * @param digitalElevationModel     another way to measure elevation
-     * @param timezone                  timezone for this location
-     * @param modificationDate          date of last modification for the GeoNames record
-     * @param gazetteerRecord           the gazetteer record
-     */
-    public GeoName(
-            int geonameID,
-            String name,
-            String asciiName,
-            List<String> alternateNames,
-            String preferredName,
-            Double latitude,
-            Double longitude,
-            FeatureClass featureClass,
-            FeatureCode featureCode,
-            CountryCode primaryCountryCode,
-            List<CountryCode> alternateCountryCodes,
-            String admin1Code,
-            String admin2Code,
-            String admin3Code,
-            String admin4Code,
-            Long population,
-            Integer elevation,
-            Integer digitalElevationModel,
-            TimeZone timezone,
-            Date modificationDate,
-            String gazetteerRecord) {
-        this.geonameID = geonameID;
-        this.name = name;
-        this.asciiName = asciiName;
-        if (alternateNames != null) {
-            // defensive copy
-            this.alternateNames = Collections.unmodifiableList(new ArrayList<String>(alternateNames));
-        } else {
-            // ensure this is never null
-            this.alternateNames = Collections.EMPTY_LIST;
-        }
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.primaryCountryCode = primaryCountryCode;
-        String pccName = primaryCountryCode != null ? primaryCountryCode.name : "";
-        if (alternateCountryCodes != null) {
-            // defensive copy
-            this.alternateCountryCodes = Collections.unmodifiableList(new ArrayList<CountryCode>(alternateCountryCodes));
-        } else {
-            // ensure this is never null
-            this.alternateCountryCodes = Collections.EMPTY_LIST;
-        }
-        this.featureClass = featureClass;
-        // configure the feature code so top-level territories are distinguishable
-        if (featureCode == FeatureCode.TERR) {
-            boolean topLevel = (this.name != null && !this.name.isEmpty() && this.name.equals(pccName)) ||
-                    (this.asciiName != null && !this.asciiName.isEmpty() && this.asciiName.equals(pccName)) ||
-                    this.alternateNames.contains(pccName);
-            this.featureCode = topLevel ? FeatureCode.TERRI : FeatureCode.TERR;
-        } else {
-            this.featureCode = featureCode;
-        }
-        // if this is a top level division, use the primary country name as the preferred name; otherwise
-        // use the name provided or null
-        boolean usePcc = TOP_LEVEL_FEATURES.contains(featureCode) && !pccName.isEmpty() &&
-                ((this.name != null && !this.name.isEmpty() && this.name.equals(pccName)) ||
-                (this.asciiName != null && !this.asciiName.isEmpty() && this.asciiName.equals(pccName)) ||
-                this.alternateNames.contains(pccName));
-        if (usePcc) {
-            this.preferredName = pccName;
-        } else {
-            this.preferredName = preferredName != null && !preferredName.trim().isEmpty() ? preferredName.trim() : null;
-        }
-
-        this.admin1Code = admin1Code;
-        this.admin2Code = admin2Code;
-        this.admin3Code = admin3Code;
-        this.admin4Code = admin4Code;
-        this.population = population;
-        this.elevation = elevation;
-        this.digitalElevationModel = digitalElevationModel;
-        this.timezone = timezone != null ? (TimeZone) timezone.clone() : null;
-        this.modificationDate = modificationDate != null ? new Date(modificationDate.getTime()) : null;
-        this.gazetteerRecord = gazetteerRecord;
-    }
-
-
-    /**
-     * Builds a {@link GeoName} object based on a single gazetteer
-     * record in the GeoNames geographical database.
-     *
-     * @param inputLine     single line of tab-delimited text representing one record from the GeoNames gazetteer
-     * @return              new GeoName object
-     */
-    public static GeoName parseFromGeoNamesRecord(String inputLine) {
-        return parseFromGeoNamesRecord(inputLine, null);
-    }
-
-    /**
-     * Builds a {@link GeoName} object based on a single gazetteer
-     * record in the GeoNames geographical database.
-     *
-     * @param inputLine     single line of tab-delimited text representing one record from the GeoNames gazetteer
-     * @param preferredName the preferred name of this GeoName as indicated by the GeoNames alternate names table
-     * @return              new GeoName object
-     */
-    public static GeoName parseFromGeoNamesRecord(final String inputLine, final String preferredName) {
-        String[] ancestry = inputLine.split("\n");
-        GeoName geoName = parseGeoName(ancestry[0], preferredName);
-        // if more records exist, assume they are the ancestory of the target GeoName
-        if (ancestry.length > 1) {
-            GeoName current = geoName;
-            for (int idx = 1; idx < ancestry.length; idx++) {
-                GeoName parent = parseGeoName(ancestry[idx], null);
-                if (!current.setParent(parent)) {
-                    LOG.error("Invalid ancestry path for GeoName [{}]: {}", geoName, inputLine.replaceAll("\n", " |@| "));
-                    break;
-                }
-                current = parent;
-            }
-        }
-        return geoName;
-    }
-
-    private static GeoName parseGeoName(final String inputLine, final String preferredName) {
-        // GeoNames gazetteer entries are tab-delimited
-        String[] tokens = inputLine.split("\t");
-
-        // initialize each field with the corresponding token
-        int geonameID = Integer.parseInt(tokens[0]);
-        String name = tokens[1];
-        String asciiName = tokens[2];
-
-        List<String> alternateNames;
-        if (tokens[3].length() > 0) {
-            // better to pass empty array than array containing empty String ""
-            alternateNames = Arrays.asList(tokens[3].split(","));
-        } else alternateNames = new ArrayList<String>();
-
-        double latitude;
-        try {
-            latitude = Double.parseDouble(tokens[4]);
-        } catch (NumberFormatException e) {
-            latitude = OUT_OF_BOUNDS;
-        }
-
-        double longitude;
-        try {
-            longitude = Double.parseDouble(tokens[5]);
-        } catch (NumberFormatException e) {
-            longitude = OUT_OF_BOUNDS;
-        }
-
-        FeatureClass featureClass;
-        if (tokens[6].length() > 0) {
-            featureClass = FeatureClass.valueOf(tokens[6]);
-        } else featureClass = FeatureClass.NULL; // not available
-
-        FeatureCode featureCode;
-        if (tokens[7].length() > 0) {
-            featureCode = FeatureCode.valueOf(tokens[7]);
-        } else featureCode = FeatureCode.NULL; // not available
-
-        CountryCode primaryCountryCode;
-        if (tokens[8].length() > 0) {
-            primaryCountryCode = CountryCode.valueOf(tokens[8]);
-        } else primaryCountryCode = CountryCode.NULL; // No Man's Land
-
-        List<CountryCode> alternateCountryCodes = new ArrayList<CountryCode>();
-        if (tokens[9].length() > 0) {
-            // don't pass list only containing empty String ""
-            for (String code : tokens[9].split(",")) {
-                if (code.length() > 0) // check for malformed data
-                    alternateCountryCodes.add(CountryCode.valueOf(code));
-            }
-        }
-
-        String admin1Code = tokens[10];
-        String admin2Code = tokens[11];
-
-        String admin3Code;
-        String admin4Code;
-        long population;
-        int elevation;
-        int digitalElevationModel;
-        TimeZone timezone;
-        Date modificationDate;
-
-        // check for dirty data...
-        if (tokens.length < 19) {
-            // GeoNames record format is corrupted, don't trust any
-            // data after this point
-            admin3Code = "";
-            admin4Code = "";
-            population = OUT_OF_BOUNDS;
-            elevation = OUT_OF_BOUNDS;
-            digitalElevationModel = OUT_OF_BOUNDS;
-            timezone = null;
-            modificationDate = new Date(0);
-        } else { // everything looks ok, soldiering on...
-            admin3Code = tokens[12];
-            admin4Code = tokens[13];
-            try {
-                population = Long.parseLong(tokens[14]);
-            } catch (NumberFormatException e) {
-                population = OUT_OF_BOUNDS;
-            }
-            try {
-                elevation = Integer.parseInt(tokens[15]);
-            } catch (NumberFormatException e) {
-                elevation = OUT_OF_BOUNDS;
-            }
-            try {
-                digitalElevationModel = Integer.parseInt(tokens[16]);
-            } catch (NumberFormatException e) {
-                digitalElevationModel = OUT_OF_BOUNDS;
-            }
-            timezone = TimeZone.getTimeZone(tokens[17]);
-            try {
-                modificationDate = new SimpleDateFormat("yyyy-MM-dd").parse(tokens[18]);
-            } catch (ParseException e) {
-                modificationDate = new Date(0);
-            }
-        }
-
-        return new GeoName(geonameID, name, asciiName, alternateNames, preferredName,
-                latitude, longitude, featureClass, featureCode,
-                primaryCountryCode, alternateCountryCodes, admin1Code,
-                admin2Code, admin3Code, admin4Code, population,
-                elevation, digitalElevationModel, timezone,
-                modificationDate, inputLine);
-    }
-
-    private static int getAdminLevel(final FeatureClass fClass, final FeatureCode fCode) {
-        return getAdminLevel(fClass, fCode, null, null, null);
-    }
-
-    private static int getAdminLevel(final FeatureClass fClass, final FeatureCode fCode, final String geoname, final List<String> altNames, final String countryName) {
-        int admLevel = Integer.MAX_VALUE;
-        if (fClass == FeatureClass.A) {
-            if (fCode == null) {
-                admLevel = -1;
-            } else if (fCode == FeatureCode.TERR) {
-                admLevel = 1;
-            } else if (fCode == FeatureCode.PRSH) {
-                admLevel = 1;
-            } else if (TOP_LEVEL_FEATURES.contains(fCode)) {
-                admLevel = 0;
-            } else {
-                Matcher matcher = ADM_LEVEL_REGEX.matcher(fCode.name());
-                if (matcher.matches()) {
-                    admLevel = Integer.parseInt(matcher.group(1));
-                }
-            }
-        }
-        return admLevel;
-    }
-
-    /**
-     * For pretty-printing.
-     *
-     */
-    @Override
-    public String toString() {
-        return getPreferredName() + " (" + getPrimaryCountryName() + ", " + admin1Code + ")" + " [pop: " + population + "] <" + geonameID + ">";
-    }
+    String getPrimaryCountryName();
 
     /**
      * Get the ancestry key that can be used to identify the direct administrative
-     * parent of this GeoName.  See {@link GeoName#getAncestryKey()} for a description
+     * parent of this GeoName.  See {@link com.bericotech.clavin.gazetteer.GeoName#getAncestryKey()} for a description
      * of an ancestry key.
      *
      * For example, the GeoName "Reston, VA" is found in
@@ -485,27 +76,23 @@ public class GeoName {
      * </ul>
      *
      * Its parent ancestor key is "US.VA.059", which is the key returned by
-     * {@link GeoName#getAncestryKey()} for the GeoName "Fairfax County."
+     * {@link com.bericotech.clavin.gazetteer.GeoName#getAncestryKey()} for the GeoName "Fairfax County."
      *
      * @return the ancestry key of the direct administrative parent of this GeoName; will be
      *         <code>null</code> for top-level elements such as countries
      */
-    public String getParentAncestryKey() {
-        String key = buildAncestryKey(FeatureCode.ADM4, false);
-        // return null if the key is empty; that means we are a top-level administrative component
-        return !key.isEmpty() ? key : null;
-    }
+    String getParentAncestryKey();
 
     /**
      * Get the ancestry key that can be used to identify this administrative division.
      * This method returns <code>null</code> for all feature types except the following
-     * {@link FeatureClass#A} records:
+     * {@link com.bericotech.clavin.gazetteer.FeatureClass#A} records:
      * <ul>
-     *   <li>Country ({@link FeatureCode#PCL})</li>
-     *   <li>First Administrative Division ({@link FeatureCode#ADM1})</li>
-     *   <li>Second Administrative Division ({@link FeatureCode#ADM2})</li>
-     *   <li>Third Administrative Division ({@link FeatureCode#ADM3})</li>
-     *   <li>Fourth Administrative Division ({@link FeatureCode#ADM4})</li>
+     *   <li>Country ({@link com.bericotech.clavin.gazetteer.FeatureCode#PCL})</li>
+     *   <li>First Administrative Division ({@link com.bericotech.clavin.gazetteer.FeatureCode#ADM1})</li>
+     *   <li>Second Administrative Division ({@link com.bericotech.clavin.gazetteer.FeatureCode#ADM2})</li>
+     *   <li>Third Administrative Division ({@link com.bericotech.clavin.gazetteer.FeatureCode#ADM3})</li>
+     *   <li>Fourth Administrative Division ({@link com.bericotech.clavin.gazetteer.FeatureCode#ADM4})</li>
      * </ul>
      *
      * The ancestry key includes the country and administrative division codes for all
@@ -532,49 +119,13 @@ public class GeoName {
      * @return the ancestry key for this administrative division or <code>null</code> if this
      *         GeoName is not an administrative division or its ancestry key cannot be derived.
      */
-    public String getAncestryKey() {
-        boolean hasKey = featureClass == FeatureClass.A && VALID_ADMIN_ANCESTORS.contains(featureCode);
-        if (hasKey) {
-            String myCode;
-            switch (featureCode) {
-                case ADM1:
-                    myCode = admin1Code;
-                    break;
-                case ADM2:
-                    myCode = admin2Code;
-                    break;
-                case ADM3:
-                    myCode = admin3Code;
-                    break;
-                case ADM4:
-                    myCode = admin4Code;
-                    break;
-                case PCL:
-                case PCLD:
-                case PCLF:
-                case PCLI:
-                case PCLIX:
-                case PCLS:
-                case TERRI:
-                    myCode = primaryCountryCode != null ? primaryCountryCode.name() : null;
-                    break;
-                default:
-                    myCode = null;
-                    break;
-            }
-            hasKey = myCode != null && !myCode.trim().isEmpty();
-        }
-        String key = (hasKey ? buildAncestryKey(FeatureCode.ADM4, true) : "").trim();
-        return !key.isEmpty() ? key : null;
-    }
+    String getAncestryKey();
 
     /**
      * Is this GeoName a top-level administrative division (e.g. country, territory or similar)?
      * @return <code>true</code> if this is a top-level administrative division
      */
-    public boolean isTopLevelAdminDivision() {
-        return TOP_LEVEL_FEATURES.contains(featureCode);
-    }
+    boolean isTopLevelAdminDivision();
 
     /**
      * Is this GeoName a top-level territory? A GeoName is considered to be a
@@ -583,110 +134,33 @@ public class GeoName {
      * configured alternate names.
      * @return <code>true</code> if the GeoName is a top level territory
      */
-    public boolean isTopLevelTerritory() {
-        return featureCode == FeatureCode.TERRI;
-    }
-
-    /**
-     * Recursively builds the ancestry key for this GeoName, optionally including the
-     * key for this GeoName's administrative division if requested and applicable. See
-     * {@link GeoName#getAncestryKey()} for a description of the ancestry key. Only
-     * divisions that have a non-empty code set in this GeoName will be included in the
-     * key.
-     * @param level the administrative division at the end of the key (e.g. ADM2 to build
-     *              the key COUNTRY.ADM1.ADM2)
-     * @param includeSelf <code>true</code> to include this GeoName's code in the key
-     * @return the generated ancestry key
-     */
-    private String buildAncestryKey(final FeatureCode level, final boolean includeSelf) {
-        // if we have reached the root level, stop
-        if (level == null) {
-            return "";
-        }
-
-        String keyPart;
-        FeatureCode nextLevel;
-        switch (level) {
-            case ADM4:
-                keyPart = admin4Code;
-                nextLevel = FeatureCode.ADM3;
-                break;
-            case ADM3:
-                keyPart = admin3Code;
-                nextLevel = FeatureCode.ADM2;
-                break;
-            case ADM2:
-                keyPart = admin2Code;
-                nextLevel = FeatureCode.ADM1;
-                break;
-            case ADM1:
-                // territories will be considered level 1 if they have the same country code as their
-                // parent but cannot contain descendants so there should be no keypart for this level;
-                // all parishes are considered to be direct descendants of their containing country with
-                // no descendants; they should not have a key part at this level
-                keyPart = featureCode != FeatureCode.TERR && featureCode != FeatureCode.PRSH ? admin1Code : "";
-                nextLevel = FeatureCode.PCL;
-                break;
-            case PCL:
-                keyPart = primaryCountryCode != null && primaryCountryCode != CountryCode.NULL ? primaryCountryCode.name() : "";
-                nextLevel = null;
-                break;
-            default:
-                throw new IllegalArgumentException("Level must be one of [PCL, ADM1, ADM2, ADM3, ADM4]");
-        }
-        keyPart = keyPart.trim();
-        if (nextLevel != null && !keyPart.isEmpty()) {
-            keyPart = String.format(".%s", keyPart);
-        }
-        int keyLevel = getAdminLevel(FeatureClass.A, level);
-        int nameLevel = getAdminLevel(featureClass, featureCode, name, alternateNames, primaryCountryCode.name);
-
-        // if the requested key part is a larger administrative division than the level of the
-        // geoname or, if we are including the geoname's key part and it is the requested part,
-        // include it in the ancestry key (if not blank); otherwise, move to the next level
-        String qualifiedKey = (nameLevel > keyLevel || (includeSelf && keyLevel == nameLevel)) && !keyPart.isEmpty() ?
-                String.format("%s%s", buildAncestryKey(nextLevel, includeSelf), keyPart) :
-                buildAncestryKey(nextLevel, includeSelf);
-        // if any part of the key is missing once a lower-level component has been specified, we cannot
-        // resolve the ancestry path and an empty string should be returned.
-        if (qualifiedKey.startsWith(".") || qualifiedKey.contains("..") || qualifiedKey.endsWith(".")) {
-            qualifiedKey = "";
-        }
-        return qualifiedKey;
-    }
+    boolean isTopLevelTerritory();
 
     /**
      * Is this GeoName a descendant of the provided GeoName?
      * @param geoname the GeoName to test
      * @return <code>true</code> if the provided GeoName is hierarchically an ancestor of this GeoName
      */
-    public boolean isDescendantOf(final GeoName geoname) {
-        boolean descended = false;
-        if (geoname != null) {
-            GeoName test;
-            // empty for loop exits when parent is found or top level is reached
-            for (test = this; test != null && !test.equals(geoname); test = test.getParent());
-            descended = test != null;
-        }
-        return descended;
-    }
+    boolean isDescendantOf(GeoName geoname);
 
     /**
      * Is this GeoName an ancestor of the provided GeoName?
      * @param geoname the GeoName to test
      * @return <code>true</code> if this GeoName is hierarchically an ancestor of the provided GeoName
      */
-    public boolean isAncestorOf(final GeoName geoname) {
-        return geoname != null && geoname.isDescendantOf(this);
-    }
+    boolean isAncestorOf(GeoName geoname);
+
+    /**
+     * Get the ID of the parent of this GeoName.
+     * @return the ID of the parent of this GeoName
+     */
+    Integer getParentId();
 
     /**
      * Get the parent of this GeoName.
      * @return the configured parent of this GeoName
      */
-    public GeoName getParent() {
-        return parent;
-    }
+    GeoName getParent();
 
     /**
      * Set the parent of this GeoName.
@@ -696,128 +170,82 @@ public class GeoName {
      * @return <code>true</code> if the parent was set, <code>false</code> if
      *         the parent was not the valid parent for this GeoName
      */
-    public boolean setParent(final GeoName prnt) {
-        String myParentKey = this.getParentAncestryKey();
-        String parentKey = prnt != null ? prnt.getAncestryKey() : null;
-        boolean parentSet = false;
-        if (prnt != null) {
-            if (prnt.getFeatureClass() != FeatureClass.A || !VALID_ADMIN_ANCESTORS.contains(prnt.getFeatureCode())) {
-                LOG.error(String.format("Invalid administrative parent type [%s:%s] specified for GeoName [%s]; Parent [%s]",
-                        prnt.getFeatureClass(), prnt.getFeatureCode(), this, prnt));
-            } else if (myParentKey != null && parentKey != null && !myParentKey.startsWith(parentKey)) {
-                LOG.error(String.format("Parent ancestry key [%s] does not match the expected key [%s] for GeoName [%s]; Parent [%s]",
-                        parentKey, myParentKey, this, prnt));
-            } else if (this.equals(prnt)) {
-                LOG.warn("Attempted to set parent to self: {}", prnt);
-            } else {
-                this.parent = prnt;
-                parentSet = true;
-            }
-        }
-        return parentSet;
-    }
+    boolean setParent(GeoName prnt);
 
     /**
      * Check to see if the ancestry hierarchy has been completely resolved for this GeoName.
      * @return <code>true</code> if all administrative parents have been resolved
      */
-    public boolean isAncestryResolved() {
-        // this GeoName is considered resolved if it is a top level administrative division,
-        // it is unresolvable, or all parents up to a top-level element have been configured
-        return getAdminLevel(featureClass, featureCode, name, alternateNames, primaryCountryCode.name) <= 0 ||
-                getParentAncestryKey() == null || (parent != null && parent.isAncestryResolved());
-    }
+    boolean isAncestryResolved();
 
     /**
      * Get the ID of the record in geonames database.
      * @return the ID
      */
-    public int getGeonameID() {
-        return geonameID;
-    }
+    int getGeonameID();
 
     /**
      * Get the name of the geographical point (UTF-8).
      * @return the name
      */
-    public String getName() {
-        return name;
-    }
+    String getName();
 
     /**
      * Get the name of the geographical point in plain ascii characters.
      * @return the plain ascii name
      */
-    public String getAsciiName() {
-        return asciiName;
-    }
+    String getAsciiName();
 
     /**
      * Get the alternate names for the location.
      * @return the alternate names; an empty List if none
      */
-    public List<String> getAlternateNames() {
-        return alternateNames;
-    }
+    List<String> getAlternateNames();
 
     /**
      * Gets the preferred name of this GeoName, if configured,
      * otherwise returns the name.
      * @return the preferred name
      */
-    public String getPreferredName() {
-        return preferredName != null ? preferredName : name;
-    }
+    String getPreferredName();
 
     /**
      * Get the latitude in decimal degrees.
      * @return the latitude
      */
-    public double getLatitude() {
-        return latitude;
-    }
+    double getLatitude();
 
     /**
      * Get the longitude in decimal degrees.
      * @return the longitude
      */
-    public double getLongitude() {
-        return longitude;
-    }
+    double getLongitude();
 
     /**
      * Get the major feature category.
      * See http://www.geonames.org/export/codes.html
      * @return the major feature category
      */
-    public FeatureClass getFeatureClass() {
-        return featureClass;
-    }
+    FeatureClass getFeatureClass();
 
     /**
      * Get the feature code.
      * See http://www.geonames.org/export/codes.html
      * @return the feature code
      */
-    public FeatureCode getFeatureCode() {
-        return featureCode;
-    }
+    FeatureCode getFeatureCode();
 
     /**
      * Get the primary ISO-3166 2-letter country code.
      * @return the primary country code
      */
-    public CountryCode getPrimaryCountryCode() {
-        return primaryCountryCode;
-    }
+    CountryCode getPrimaryCountryCode();
 
     /**
      * Get the alternate ISO-3166 2-letter country codes.
      * @return the alternate country codes; empty List if none
      */
-    public List<CountryCode> getAlternateCountryCodes() {
-        return alternateCountryCodes;
-    }
+    List<CountryCode> getAlternateCountryCodes();
 
     /**
      * Get the code for the first level administrative division (e.g. a
@@ -826,50 +254,38 @@ public class GeoName {
      * additional level between country and FIPS code.
      * @return the code for the first administrative division
      */
-    public String getAdmin1Code() {
-        return admin1Code;
-    }
+    String getAdmin1Code();
 
     /**
      * Get the code for the second level administrative division (e.g. a
      * county in the US).
      * @return the code for the second administrative division
      */
-    public String getAdmin2Code() {
-        return admin2Code;
-    }
+    String getAdmin2Code();
 
     /**
      * Get the code for the third level administrative division.
      * @return the code for the third administrative division
      */
-    public String getAdmin3Code() {
-        return admin3Code;
-    }
+    String getAdmin3Code();
 
     /**
      * Get the code for the fourth level administrative division.
      * @return the code for the fourth administrative division
      */
-    public String getAdmin4Code() {
-        return admin4Code;
-    }
+    String getAdmin4Code();
 
     /**
      * Get the total number of inhabitants.
      * @return the population
      */
-    public long getPopulation() {
-        return population;
-    }
+    long getPopulation();
 
     /**
      * Get the elevation in meters.
      * @return the elevation
      */
-    public int getElevation() {
-        return elevation;
-    }
+    int getElevation();
 
     /**
      * Get the digital elevation model, srtm3 or gtopo30, average
@@ -877,64 +293,30 @@ public class GeoName {
      * area in meters, integer.  srtm processed by cgiar/ciat.
      * @return the average elevation in meters
      */
-    public int getDigitalElevationModel() {
-        return digitalElevationModel;
-    }
+    int getDigitalElevationModel();
 
     /**
      * Get the time zone for the geographical point.
      * @return the time zone; may be <code>null</code>
      */
-    public TimeZone getTimezone() {
-        // defensive copy
-        return timezone != null ? (TimeZone) timezone.clone() : null;
-    }
+    TimeZone getTimezone();
 
     /**
      * Get the last modification date in the GeoNames database.
      * @return the last modification date; may be <code>null</code>
      */
-    public Date getModificationDate() {
-        // defensive copy
-        return modificationDate != null ? new Date(modificationDate.getTime()) : null;
-    }
+    Date getModificationDate();
 
     /**
      * Get the gazetteer record for this GeoName.
      * @return the gazetteer record this GeoName was parsed from
      */
-    public String getGazetteerRecord() {
-        return gazetteerRecord;
-    }
+    String getGazetteerRecord();
 
     /**
      * Get the gazetteer records for this GeoName and its ancestors, separated
      * by newline characters.
      * @return the newline-separated gazetteer records for this GeoName and its ancestors.
      */
-    public String getGazetteerRecordWithAncestry() {
-        return parent != null ? String.format("%s\n%s", gazetteerRecord, parent.getGazetteerRecordWithAncestry()) : gazetteerRecord;
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = 3;
-        hash = 83 * hash + this.geonameID;
-        return hash;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final GeoName other = (GeoName) obj;
-        if (this.geonameID != other.geonameID) {
-            return false;
-        }
-        return true;
-    }
+    String getGazetteerRecordWithAncestry();
 }

--- a/src/main/java/com/bericotech/clavin/gazetteer/LazyAncestryGeoName.java
+++ b/src/main/java/com/bericotech/clavin/gazetteer/LazyAncestryGeoName.java
@@ -1,0 +1,236 @@
+package com.bericotech.clavin.gazetteer;
+
+import com.bericotech.clavin.ClavinException;
+import com.bericotech.clavin.gazetteer.query.AncestryMode;
+import com.bericotech.clavin.gazetteer.query.Gazetteer;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+/**
+ * This GeoName can be configured to lazily load its ancestry when its parent
+ * is first requested or to load its ancestry only when explicitly requested
+ * through a Gazetteer.
+ */
+public class LazyAncestryGeoName implements GeoName {
+    /** The wrapped GeoName. */
+    private final GeoName geoName;
+
+    /** The GeoName ID of this GeoName's parent. */
+    private final Integer parentId;
+
+    /** The Gazetteer used to resolve the ancestry of the target GeoName. */
+    private final Gazetteer gazetteer;
+
+    /**
+     * Creates a LazyAncestryGeoName whose ancestry must be manually loaded.
+     * @param geoName the GeoName to wrap
+     * @param parentId the ID of the parent of this GeoName
+     */
+    public LazyAncestryGeoName(final GeoName geoName, final Integer parentId) {
+        this(geoName, parentId, null);
+    }
+
+    /**
+     * Creates a LazyAncestryGeoName that lazily loads the ancestry of the wrapped
+     * GeoName when its parent is first requested. If no Gazetteer is provided,
+     * ancestry must be manually loaded.
+     * @param geoName the GeoName to wrap
+     * @param parentId the ID of the parent of this GeoName
+     * @param gazetteer the Gazetteer used for ancestry resolution; if null, ancestry must be loaded manually
+     */
+    public LazyAncestryGeoName(final GeoName geoName, final Integer parentId, final Gazetteer gazetteer) {
+        this.geoName = geoName;
+        this.parentId = parentId;
+        this.gazetteer = gazetteer;
+    }
+
+    @Override
+    public Integer getParentId() {
+        return parentId;
+    }
+
+    @Override
+    public GeoName getParent() {
+        if (gazetteer != null && !geoName.isAncestryResolved()) {
+            try {
+                geoName.setParent(gazetteer.getGeoName(parentId, AncestryMode.ON_CREATE));
+            } catch (ClavinException ce) {
+                throw new RuntimeException(String.format("Error lazy-loading ancestry for %s", geoName), ce);
+            }
+        }
+        return geoName.getParent();
+    }
+
+    @Override
+    public boolean setParent(GeoName prnt) {
+        return geoName.setParent(prnt);
+    }
+
+    @Override
+    public String getPrimaryCountryName() {
+        return geoName.getPrimaryCountryName();
+    }
+
+    @Override
+    public String getParentAncestryKey() {
+        return geoName.getParentAncestryKey();
+    }
+
+    @Override
+    public String getAncestryKey() {
+        return geoName.getAncestryKey();
+    }
+
+    @Override
+    public boolean isTopLevelAdminDivision() {
+        return geoName.isTopLevelAdminDivision();
+    }
+
+    @Override
+    public boolean isTopLevelTerritory() {
+        return geoName.isTopLevelTerritory();
+    }
+
+    @Override
+    public boolean isDescendantOf(GeoName geoname) {
+        return geoName.isDescendantOf(geoname);
+    }
+
+    @Override
+    public boolean isAncestorOf(GeoName geoname) {
+        return geoName.isAncestorOf(geoname);
+    }
+
+    @Override
+    public boolean isAncestryResolved() {
+        return geoName.isAncestryResolved();
+    }
+
+    @Override
+    public int getGeonameID() {
+        return geoName.getGeonameID();
+    }
+
+    @Override
+    public String getName() {
+        return geoName.getName();
+    }
+
+    @Override
+    public String getAsciiName() {
+        return geoName.getAsciiName();
+    }
+
+    @Override
+    public List<String> getAlternateNames() {
+        return geoName.getAlternateNames();
+    }
+
+    @Override
+    public String getPreferredName() {
+        return geoName.getPreferredName();
+    }
+
+    @Override
+    public double getLatitude() {
+        return geoName.getLatitude();
+    }
+
+    @Override
+    public double getLongitude() {
+        return geoName.getLongitude();
+    }
+
+    @Override
+    public FeatureClass getFeatureClass() {
+        return geoName.getFeatureClass();
+    }
+
+    @Override
+    public FeatureCode getFeatureCode() {
+        return geoName.getFeatureCode();
+    }
+
+    @Override
+    public CountryCode getPrimaryCountryCode() {
+        return geoName.getPrimaryCountryCode();
+    }
+
+    @Override
+    public List<CountryCode> getAlternateCountryCodes() {
+        return geoName.getAlternateCountryCodes();
+    }
+
+    @Override
+    public String getAdmin1Code() {
+        return geoName.getAdmin1Code();
+    }
+
+    @Override
+    public String getAdmin2Code() {
+        return geoName.getAdmin2Code();
+    }
+
+    @Override
+    public String getAdmin3Code() {
+        return geoName.getAdmin3Code();
+    }
+
+    @Override
+    public String getAdmin4Code() {
+        return geoName.getAdmin4Code();
+    }
+
+    @Override
+    public long getPopulation() {
+        return geoName.getPopulation();
+    }
+
+    @Override
+    public int getElevation() {
+        return geoName.getElevation();
+    }
+
+    @Override
+    public int getDigitalElevationModel() {
+        return geoName.getDigitalElevationModel();
+    }
+
+    @Override
+    public TimeZone getTimezone() {
+        return geoName.getTimezone();
+    }
+
+    @Override
+    public Date getModificationDate() {
+        return geoName.getModificationDate();
+    }
+
+    @Override
+    public String getGazetteerRecord() {
+        return geoName.getGazetteerRecord();
+    }
+
+    @Override
+    public String getGazetteerRecordWithAncestry() {
+        return geoName.getGazetteerRecordWithAncestry();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        LazyAncestryGeoName that = (LazyAncestryGeoName) o;
+
+        if (!geoName.equals(that.geoName)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return geoName.hashCode();
+    }
+}

--- a/src/main/java/com/bericotech/clavin/gazetteer/LazyAncestryGeoName.java
+++ b/src/main/java/com/bericotech/clavin/gazetteer/LazyAncestryGeoName.java
@@ -52,7 +52,7 @@ public class LazyAncestryGeoName implements GeoName {
 
     @Override
     public GeoName getParent() {
-        if (gazetteer != null && !geoName.isAncestryResolved()) {
+        if (gazetteer != null && parentId != null && !geoName.isAncestryResolved()) {
             try {
                 geoName.setParent(gazetteer.getGeoName(parentId, AncestryMode.ON_CREATE));
             } catch (ClavinException ce) {

--- a/src/main/java/com/bericotech/clavin/gazetteer/query/AncestryMode.java
+++ b/src/main/java/com/bericotech/clavin/gazetteer/query/AncestryMode.java
@@ -1,0 +1,51 @@
+/*#####################################################################
+ *
+ * CLAVIN (Cartographic Location And Vicinity INdexer)
+ * ---------------------------------------------------
+ *
+ * Copyright (C) 2012-2013 Berico Technologies
+ * http://clavin.bericotechnologies.com
+ *
+ * ====================================================================
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * ====================================================================
+ *
+ * HierarchyMode.java
+ *
+ *###################################################################*/
+
+package com.bericotech.clavin.gazetteer.query;
+
+/**
+ * Controls the resolution of the hierarchy of political divisions
+ * containing a ResolvedLocation.
+ */
+public enum AncestryMode {
+    /**
+     * Resolve the hierarchy when locations are created.
+     */
+    ON_CREATE,
+    /**
+     * Resolve the hierarchy when the parent of a location is
+     * requested. Lazily loaded hierarchies may also be manually
+     * loaded to improve performance by loading the hierarchy
+     * for multiple locations at once.
+     */
+    LAZY,
+    /**
+     * Do not resolve hierarchy unless manually requested.
+     */
+    MANUAL;
+}

--- a/src/main/java/com/bericotech/clavin/gazetteer/query/Gazetteer.java
+++ b/src/main/java/com/bericotech/clavin/gazetteer/query/Gazetteer.java
@@ -31,6 +31,7 @@ package com.bericotech.clavin.gazetteer.query;
 import com.bericotech.clavin.ClavinException;
 import com.bericotech.clavin.gazetteer.GeoName;
 import com.bericotech.clavin.resolver.ResolvedLocation;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -49,10 +50,34 @@ public interface Gazetteer {
     List<ResolvedLocation> getClosestLocations(final GazetteerQuery query) throws ClavinException;
 
     /**
-     * Retrieves the GeoName with the provided ID.
+     * Retrieves the GeoName with the provided ID, lazily loading its ancestry.
      * @param geonameId           the ID of the requested GeoName
      * @return                    the requested GeoName or <code>null</code> if not found
      * @throws ClavinException    if an error occurs
      */
     GeoName getGeoName(final int geonameId) throws ClavinException;
+
+    /**
+     * Retrieves the GeoName with the provided ID, resolving ancestry according
+     * to the provided method.
+     * @param geonameId           the ID of the requested GeoName
+     * @param ancestryMode        the mode used to load ancestry for the GeoName
+     * @return                    the requested GeoName or <code>null</code> if not found
+     * @throws ClavinException    if an error occurs
+     */
+    GeoName getGeoName(final int geonameId, final AncestryMode ancestryMode) throws ClavinException;
+
+    /**
+     * Retrieve the full ancestry for the provided GeoNames.
+     * @param geoNames            the GeoNames whose ancestry will be loaded
+     * @throws ClavinException    if an error occurs
+     */
+    void loadAncestry(final GeoName... geoNames) throws ClavinException;
+
+    /**
+     * Retrieve the full ancestry for the provided GeoNames.
+     * @param geoNames            the GeoNames whose ancestry will be loaded
+     * @throws ClavinException    if an error occurs
+     */
+    void loadAncestry(final Collection<GeoName> geoNames) throws ClavinException;
 }

--- a/src/main/java/com/bericotech/clavin/gazetteer/query/GazetteerQuery.java
+++ b/src/main/java/com/bericotech/clavin/gazetteer/query/GazetteerQuery.java
@@ -58,6 +58,11 @@ public class GazetteerQuery {
     private final FuzzyMode fuzzyMode;
 
     /**
+     * Indicates how the ancestry of the matched locations should be loaded.
+     */
+    private final AncestryMode ancestryMode;
+
+    /**
      * Should historical locations be included?
      */
     private final boolean includeHistorical;
@@ -86,6 +91,7 @@ public class GazetteerQuery {
      * @param occurrence the location occurrence
      * @param maxResults the maximum number of results
      * @param fuzzyMode the fuzzy mode for this query
+     * @param ancestryMode the ancestry loading mode for this query
      * @param includeHistorical <code>true</code> to include historical locations
      * @param filterDupes <code>true</code> to return only the highest scoring match for each individual location
      * @param parentIds the set of parent IDs to restrict the search to; these will be OR'ed
@@ -93,11 +99,12 @@ public class GazetteerQuery {
      */
     @SuppressWarnings("unchecked")
     public GazetteerQuery(final LocationOccurrence occurrence, final int maxResults, final FuzzyMode fuzzyMode,
-            final boolean includeHistorical, final boolean filterDupes, final Set<Integer> parentIds,
-            final Set<FeatureCode> featureCodes) {
+            final AncestryMode ancestryMode, final boolean includeHistorical, final boolean filterDupes,
+            final Set<Integer> parentIds, final Set<FeatureCode> featureCodes) {
         this.occurrence = occurrence;
         this.maxResults = maxResults;
         this.fuzzyMode = fuzzyMode;
+        this.ancestryMode = ancestryMode;
         this.includeHistorical = includeHistorical;
         this.filterDupes = filterDupes;
         this.parentIds = parentIds != null ? new HashSet<Integer>(parentIds) : Collections.EMPTY_SET;
@@ -126,6 +133,15 @@ public class GazetteerQuery {
      */
     public FuzzyMode getFuzzyMode() {
         return fuzzyMode;
+    }
+
+    /**
+     * Indicates how the ancestry, the hierarchy of political divisions, for matching
+     * locations should be loaded.
+     * @return the ancestry mode
+     */
+    public AncestryMode getAncestryMode() {
+        return ancestryMode;
     }
 
     /**

--- a/src/main/java/com/bericotech/clavin/gazetteer/query/QueryBuilder.java
+++ b/src/main/java/com/bericotech/clavin/gazetteer/query/QueryBuilder.java
@@ -46,6 +46,7 @@ import java.util.Set;
 public class QueryBuilder {
     private static final int DEFAULT_MAX_RESULTS = 10;
     private static final FuzzyMode DEFAULT_FUZZY_MODE = FuzzyMode.OFF;
+    private static final AncestryMode DEFAULT_HIERARCHY_MODE = AncestryMode.LAZY;
     private static final boolean DEFAULT_INCLUDE_HISTORICAL = true;
     private static final boolean DEFAULT_FILTER_DUPES = false;
 
@@ -110,6 +111,7 @@ public class QueryBuilder {
     private LocationOccurrence location;
     private int maxResults = DEFAULT_MAX_RESULTS;
     private FuzzyMode fuzzyMode = DEFAULT_FUZZY_MODE;
+    private AncestryMode ancestryMode = DEFAULT_HIERARCHY_MODE;
     private boolean includeHistorical = DEFAULT_INCLUDE_HISTORICAL;
     private boolean filterDupes = DEFAULT_FILTER_DUPES;
     private Set<Integer> parentIds = new HashSet<Integer>();
@@ -120,7 +122,7 @@ public class QueryBuilder {
      * @return a {@link GazetteerQuery} configuration object
      */
     public GazetteerQuery build() {
-        return new GazetteerQuery(location, maxResults, fuzzyMode, includeHistorical, filterDupes, parentIds, featureCodes);
+        return new GazetteerQuery(location, maxResults, fuzzyMode, ancestryMode, includeHistorical, filterDupes, parentIds, featureCodes);
     }
 
     /**
@@ -185,6 +187,24 @@ public class QueryBuilder {
      */
     public QueryBuilder fuzzyMode(final FuzzyMode mode) {
         fuzzyMode = mode;
+        return this;
+    }
+
+    /**
+     * Get the current ancestry loading mode.
+     * @return the ancestry loading mode
+     */
+    public AncestryMode ancestryMode() {
+        return ancestryMode;
+    }
+
+    /**
+     * Configure the ancestry loading mode.
+     * @param mode the ancestry loading mode
+     * @return this
+     */
+    public QueryBuilder ancestryMode(final AncestryMode mode) {
+        ancestryMode = mode;
         return this;
     }
 

--- a/src/main/java/com/bericotech/clavin/index/IndexDirectoryBuilder.java
+++ b/src/main/java/com/bericotech/clavin/index/IndexDirectoryBuilder.java
@@ -3,6 +3,7 @@ package com.bericotech.clavin.index;
 import static com.bericotech.clavin.index.IndexField.*;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.bericotech.clavin.gazetteer.BasicGeoName;
 import com.bericotech.clavin.gazetteer.CountryCode;
 import com.bericotech.clavin.gazetteer.FeatureClass;
 import com.bericotech.clavin.gazetteer.FeatureCode;
@@ -150,7 +151,7 @@ public class IndexDirectoryBuilder {
                     if (count % 100000 == 0 ) {
                         LOG.info("rowcount: " + count);
                     }
-                    GeoName geoName = GeoName.parseFromGeoNamesRecord(line);
+                    GeoName geoName = BasicGeoName.parseFromGeoNamesRecord(line);
                     resolveAncestry(geoName);
                 } catch (IOException e) {
                     LOG.info("Skipping... Error on line: {}", line);

--- a/src/main/java/com/bericotech/clavin/resolver/LocationResolver.java
+++ b/src/main/java/com/bericotech/clavin/resolver/LocationResolver.java
@@ -1,7 +1,6 @@
 package com.bericotech.clavin.resolver;
 
 import com.bericotech.clavin.extractor.LocationOccurrence;
-import com.bericotech.clavin.gazetteer.GeoName;
 import java.util.List;
 
 /*#####################################################################
@@ -46,7 +45,7 @@ import java.util.List;
 public interface LocationResolver {
     /**
      * Resolves the supplied list of location names into
-     * {@link ResolvedLocation}s containing {@link GeoName} objects.
+     * {@link ResolvedLocation}s containing {@link com.bericotech.clavin.gazetteer.GeoName} objects.
      *
      * @param locations     list of location names to be resolved
      * @param fuzzy         switch for turning on/off fuzzy matching

--- a/src/main/java/com/bericotech/clavin/resolver/ResolvedLocation.java
+++ b/src/main/java/com/bericotech/clavin/resolver/ResolvedLocation.java
@@ -37,7 +37,7 @@ import com.bericotech.clavin.gazetteer.GeoName;
  * Object produced by resolving a location name against gazetteer
  * records.
  *
- * Encapsulates a {@link GeoName} object representing the best match
+ * Encapsulates a {@link com.bericotech.clavin.gazetteer.GeoName} object representing the best match
  * between a given location name and gazetter record, along with some
  * information about the geographic entity resolution process.
  *

--- a/src/main/java/com/bericotech/clavin/resolver/multipart/MultipartLocationResolver.java
+++ b/src/main/java/com/bericotech/clavin/resolver/multipart/MultipartLocationResolver.java
@@ -30,6 +30,7 @@ package com.bericotech.clavin.resolver.multipart;
 
 import com.bericotech.clavin.ClavinException;
 import com.bericotech.clavin.gazetteer.CountryCode;
+import com.bericotech.clavin.gazetteer.query.AncestryMode;
 import com.bericotech.clavin.gazetteer.query.FuzzyMode;
 import com.bericotech.clavin.gazetteer.query.Gazetteer;
 import com.bericotech.clavin.gazetteer.GeoName;
@@ -102,6 +103,7 @@ public class MultipartLocationResolver {
                 // necessary, or desirable to support FILL for the multi-part resolution algorithm
                 .fuzzyMode(fuzzy ? FuzzyMode.NO_EXACT : FuzzyMode.OFF)
                 .includeHistorical(true)
+                .ancestryMode(AncestryMode.ON_CREATE)
                 .maxResults(MAX_RESULTS);
 
         // country query should only include country-like feature codes
@@ -249,6 +251,7 @@ public class MultipartLocationResolver {
                 // translate CLAVIN 1.x 'fuzzy' parameter into NO_EXACT or OFF; it isn't
                 // necessary, or desirable to support FILL for the multi-part resolution algorithm
                 .fuzzyMode(fuzzy ? FuzzyMode.NO_EXACT : FuzzyMode.OFF)
+                .ancestryMode(AncestryMode.ON_CREATE)
                 .includeHistorical(true);
         findCandidates(candidates, terms, SearchLevel.COUNTRY, matches, query);
 

--- a/src/test/java/com/bericotech/clavin/AllTestsSuite.java
+++ b/src/test/java/com/bericotech/clavin/AllTestsSuite.java
@@ -1,5 +1,6 @@
 package com.bericotech.clavin;
 
+import com.bericotech.clavin.gazetteer.BasicGeoNameTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -41,7 +42,7 @@ import org.junit.runners.Suite.SuiteClasses;
     com.bericotech.clavin.GeoParserFactoryTest.class,
     com.bericotech.clavin.extractor.ApacheExtractorTest.class,
     com.bericotech.clavin.extractor.LocationOccurrenceTest.class,
-    com.bericotech.clavin.gazetteer.GeoNameTest.class,
+    BasicGeoNameTest.class,
     com.bericotech.clavin.index.BinarySimilarityTest.class,
     com.bericotech.clavin.resolver.ResolvedLocationTest.class,
     com.bericotech.clavin.resolver.ClavinLocationResolverTest.class,

--- a/src/test/java/com/bericotech/clavin/GeoParserTest.java
+++ b/src/test/java/com/bericotech/clavin/GeoParserTest.java
@@ -9,31 +9,31 @@ import org.junit.Test;
 import com.bericotech.clavin.resolver.ResolvedLocation;
 
 /*#####################################################################
- * 
+ *
  * CLAVIN (Cartographic Location And Vicinity INdexer)
  * ---------------------------------------------------
- * 
+ *
  * Copyright (C) 2012-2013 Berico Technologies
  * http://clavin.bericotechnologies.com
- * 
+ *
  * ====================================================================
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
  * implied. See the License for the specific language governing
  * permissions and limitations under the License.
- * 
+ *
  * ====================================================================
- * 
+ *
  * GeoParserTest.java
- * 
+ *
  *###################################################################*/
 
 /**
@@ -42,12 +42,12 @@ import com.bericotech.clavin.resolver.ResolvedLocation;
  *
  */
 public class GeoParserTest {
-    
+
     // expected geonameID numbers for given location names
     int UNITED_STATES = 6252001;
     int VERMONT = 5242283;
     int MASSACHUSETTS = 6254926;
-    
+
     /**
      * Ensures we're getting good output from the end-to-end GeoParser
      * process.
@@ -57,15 +57,15 @@ public class GeoParserTest {
     public void testParse() throws Exception {
         // instantiate the CLAVIN GeoParser
         GeoParser parser = GeoParserFactory.getDefault("./IndexDirectory");
-        
+
         // sample text to be geoparsed
         String inputText = "Calvin Coolidge was the 30th president " +
                 "of the United States. He was born in Vermont and " +
                 "died in Massachusetts.";
-        
+
         // parse location names in the text into geographic entities
         List<ResolvedLocation> resolvedLocations = parser.parse(inputText);
-        
+
         // check the output
         assertEquals("Wrong number of ResolvedLocations", 3, resolvedLocations.size());
         assertEquals("Incorrect ResolvedLocation", UNITED_STATES, resolvedLocations.get(0).getGeoname().getGeonameID());
@@ -74,7 +74,6 @@ public class GeoParserTest {
         assertEquals("Incorrect position of LocationOccurance", inputText.indexOf("United States"), resolvedLocations.get(0).getLocation().getPosition());
         assertEquals("Incorrect position of LocationOccurance", inputText.indexOf("Vermont"), resolvedLocations.get(1).getLocation().getPosition());
         assertEquals("Incorrect position of LocationOccurance", inputText.indexOf("Massachusetts"), resolvedLocations.get(2).getLocation().getPosition());
-
     }
 
 }

--- a/src/test/java/com/bericotech/clavin/gazetteer/BasicGeoNameTest.java
+++ b/src/test/java/com/bericotech/clavin/gazetteer/BasicGeoNameTest.java
@@ -40,21 +40,21 @@ import org.junit.Test;
  *
  * ====================================================================
  *
- * GeoNameTest.java
+ * BasicGeoNameTest.java
  *
  *###################################################################*/
 
 /**
  * Tests to make sure GeoNames gazetteer records are properly parsed
- * into corresponding {@link GeoName} objects.
+ * into corresponding {@link BasicGeoName} objects.
  *
  */
-public class GeoNameTest {
+public class BasicGeoNameTest {
     private static class GeoRecord {
         public final String gazetteerRecord;
-        public final GeoName geoName;
+        public final BasicGeoName geoName;
 
-        public GeoRecord(final String gaz, final GeoName geo) {
+        public GeoRecord(final String gaz, final BasicGeoName geo) {
             this.gazetteerRecord = gaz;
             this.geoName = geo;
         }
@@ -86,7 +86,7 @@ public class GeoNameTest {
         String line;
         List<GeoRecord> geoRecords = new ArrayList<GeoRecord>();
         while ((line = r.readLine()) != null) {
-            geoRecords.add(new GeoRecord(line, GeoName.parseFromGeoNamesRecord(line)));
+            geoRecords.add(new GeoRecord(line, (BasicGeoName) BasicGeoName.parseFromGeoNamesRecord(line)));
         }
         r.close();
 
@@ -285,8 +285,8 @@ public class GeoNameTest {
     @Test
     public void testIsAncestryResolved_PartialResolution() {
         GeoName restonGeo = reston.geoName;
-        GeoName fairfaxCountyGeo = fairfaxCounty.geoName;
-        GeoName virginiaGeo = virginia.geoName;
+        BasicGeoName fairfaxCountyGeo = fairfaxCounty.geoName;
+        BasicGeoName virginiaGeo = virginia.geoName;
         restonGeo.setParent(fairfaxCountyGeo);
         assertFalse("only one parent set [reston], should not be resolved", restonGeo.isAncestryResolved());
         fairfaxCountyGeo.setParent(virginiaGeo);
@@ -300,9 +300,9 @@ public class GeoNameTest {
     @Test
     public void testIsAncestryResolved_FullResolution() {
         GeoName restonGeo = reston.geoName;
-        GeoName fairfaxCountyGeo = fairfaxCounty.geoName;
-        GeoName virginiaGeo = virginia.geoName;
-        GeoName unitedStatesGeo = unitedStates.geoName;
+        BasicGeoName fairfaxCountyGeo = fairfaxCounty.geoName;
+        BasicGeoName virginiaGeo = virginia.geoName;
+        BasicGeoName unitedStatesGeo = unitedStates.geoName;
         GeoName coralSeaIslandsGeo = coralSeaIslands.geoName;
 
         virginiaGeo.setParent(unitedStatesGeo);
@@ -325,7 +325,7 @@ public class GeoNameTest {
      */
     @Test
     public void testSetParent_InvalidParent() {
-        GeoName restonGeo = reston.geoName;
+        BasicGeoName restonGeo = reston.geoName;
 
         assertNull("[reston] should have no parent", restonGeo.getParent());
         assertFalse("non-administrative parent should not be allowed", restonGeo.setParent(boston.geoName));
@@ -354,9 +354,9 @@ public class GeoNameTest {
         BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(
                 new File("./src/test/resources/gazetteers/BadGeoNamesSample.txt")), "UTF-8"));
         String line;
-        ArrayList<GeoName> geonames = new ArrayList<GeoName>();
+        List<GeoName> geonames = new ArrayList<GeoName>();
         while ((line = r.readLine()) != null)
-            geonames.add(GeoName.parseFromGeoNamesRecord(line));
+            geonames.add(BasicGeoName.parseFromGeoNamesRecord(line));
         r.close();
 
         // if no exceptions are thrown, the test is assumed to have succeeded

--- a/src/test/java/com/bericotech/clavin/gazetteer/LazyAncestryGeoNameTest.java
+++ b/src/test/java/com/bericotech/clavin/gazetteer/LazyAncestryGeoNameTest.java
@@ -1,0 +1,109 @@
+/*#####################################################################
+ *
+ * CLAVIN (Cartographic Location And Vicinity INdexer)
+ * ---------------------------------------------------
+ *
+ * Copyright (C) 2012-2013 Berico Technologies
+ * http://clavin.bericotechnologies.com
+ *
+ * ====================================================================
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * ====================================================================
+ *
+ * LazyAncestryGeoNameTest.java
+ *
+ *###################################################################*/
+
+package com.bericotech.clavin.gazetteer;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+import com.bericotech.clavin.gazetteer.query.AncestryMode;
+import com.bericotech.clavin.gazetteer.query.Gazetteer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * Tests to ensure ancestry is lazily resolved.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class LazyAncestryGeoNameTest {
+    private static final int TEST_PARENT_ID = 42;
+
+    @Mock
+    private Gazetteer gazetteer;
+    @Mock
+    private GeoName geoName;
+    @Mock
+    private GeoName parent;
+
+    @Test
+    public void testGetParent_ManualResolve_NullParent() {
+        LazyAncestryGeoName instance = new LazyAncestryGeoName(geoName, TEST_PARENT_ID);
+        when(geoName.getParent()).thenReturn(null);
+        assertNull("Expected null parent for GeoName.", instance.getParent());
+        verify(geoName, never()).setParent(any(GeoName.class));
+    }
+
+    @Test
+    public void testGetParent_ManualResolve_WithParent() {
+        LazyAncestryGeoName instance = new LazyAncestryGeoName(geoName, TEST_PARENT_ID);
+        when(geoName.getParent()).thenReturn(parent);
+        assertEquals("Expected configured parent", parent, instance.getParent());
+        verify(geoName, never()).setParent(any(GeoName.class));
+    }
+
+    @Test
+    public void testGetParent_LazyResolve_NotResolved_NoParent() throws Exception {
+        LazyAncestryGeoName instance = new LazyAncestryGeoName(geoName, TEST_PARENT_ID, gazetteer);
+        when(geoName.isAncestryResolved()).thenReturn(false);
+        when(gazetteer.getGeoName(TEST_PARENT_ID, AncestryMode.ON_CREATE)).thenReturn(null);
+        assertNull("Expecting no parent resolved.", instance.getParent());
+        verify(geoName).setParent(null);
+    }
+
+    @Test
+    public void testGetParent_LazyResolve_NotResolved_FoundParent() throws Exception {
+        LazyAncestryGeoName instance = new LazyAncestryGeoName(geoName, TEST_PARENT_ID, gazetteer);
+        when(geoName.isAncestryResolved()).thenReturn(false);
+        when(geoName.getParent()).thenReturn(parent);
+        when(gazetteer.getGeoName(TEST_PARENT_ID, AncestryMode.ON_CREATE)).thenReturn(parent);
+        assertEquals("Expected resolution to mock parent.", parent, instance.getParent());
+        verify(geoName).setParent(parent);
+    }
+
+    @Test
+    public void testGetParent_LazyResolve_AlreadyResolved() throws Exception {
+        LazyAncestryGeoName instance = new LazyAncestryGeoName(geoName, TEST_PARENT_ID, gazetteer);
+        when(geoName.isAncestryResolved()).thenReturn(true);
+        when(geoName.getParent()).thenReturn(parent);
+        assertEquals("Expected resolved parent", parent, instance.getParent());
+        verify(geoName, never()).setParent(any(GeoName.class));
+        verify(gazetteer, never()).getGeoName(anyInt(), any(AncestryMode.class));
+    }
+
+    @Test
+    public void testGetParent_LazyResolve_NullParentId() throws Exception {
+        LazyAncestryGeoName instance = new LazyAncestryGeoName(geoName, null, gazetteer);
+        when(geoName.getParent()).thenReturn(null);
+        when(geoName.isAncestryResolved()).thenReturn(false);
+        assertNull("Expected null parent", instance.getParent());
+        verify(geoName, never()).setParent(any(GeoName.class));
+        verify(gazetteer, never()).getGeoName(anyInt(), any(AncestryMode.class));
+    }
+}

--- a/src/test/java/com/bericotech/clavin/resolver/ResolvedLocationTest.java
+++ b/src/test/java/com/bericotech/clavin/resolver/ResolvedLocationTest.java
@@ -3,6 +3,7 @@ package com.bericotech.clavin.resolver;
 import static org.junit.Assert.*;
 
 import com.bericotech.clavin.extractor.LocationOccurrence;
+import com.bericotech.clavin.gazetteer.BasicGeoName;
 import com.bericotech.clavin.gazetteer.GeoName;
 import org.junit.Test;
 
@@ -36,7 +37,7 @@ import org.junit.Test;
 
 /**
  * Basic tests for the {@link ResolvedLocation} class, which
- * encapsulates a {@link GeoName} object representing the best match
+ * encapsulates a {@link com.bericotech.clavin.gazetteer.GeoName} object representing the best match
  * between a given location name and gazetter record, along with some
  * information about the geographic entity resolution process.
  *
@@ -53,8 +54,8 @@ public class ResolvedLocationTest {
         String geonamesEntry2 = "478153\tReston\tReston\tReston,Рестон\t38.96872\t-77.3411\tP\tPPL\tUS\tVA\t059\t58404\t100\t102\tAmerica/New_York\t2011-05-14";
 
         // create corresponding Lucene Documents for gazetteer records
-        GeoName geoname = GeoName.parseFromGeoNamesRecord(geonamesEntry);
-        GeoName geoname2 = GeoName.parseFromGeoNamesRecord(geonamesEntry2);
+        GeoName geoname = BasicGeoName.parseFromGeoNamesRecord(geonamesEntry);
+        GeoName geoname2 = BasicGeoName.parseFromGeoNamesRecord(geonamesEntry2);
 
         // a bogus LocationOccurrence object for testing
         LocationOccurrence locationA = new LocationOccurrence("A", 0);

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,8 +7,10 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level - %msg%n</pattern>
     </encoder>
   </appender>
-   
-  <root level="ALL">
+
+  <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <!--<logger name="com.bericotech.clavin" level="debug"/>-->
 </configuration>


### PR DESCRIPTION
This pull request addresses #104, the performance hit in CLAVIN 2.0.0 due to the automatic loading of ancestry  (the containing administrative districts) for all GeoNames returned by the Gazetteer lookup. This was resulting in 1-5 additional Lucene queries for every lookup, depending on the depth of the results returned. For any number of search results, `N`, the worst case scenario (all results have unique ancestry and have 4 admin districts and a country that contain them) would be 5 queries to load `5N` ancestors from the index. This resulted in a 2-3x decrease in performance.

The solution was to configure three different methods for loading the ancestry of a GeoName, `ON_CREATE`, `LAZY`, and `MANUAL`. `ON_CREATE` behaves the same as CLAVIN 2.0.0, loading the ancestry when Gazetteer queries are executed. `LAZY`, which is now the default for all queries unless otherwise specified, triggers a load of all a GeoName's ancestors when `getParent()` is first called. This eliminates the performance hit on query but allows simple retrieval of the ancestry if it is later required. Queries running in `MANUAL` mode do not load ancestry and users will have to call the new `Gazetteer.loadAncestry()` method with the returned GeoNames in order to access their ancestors.

I also bumped the version number to 2.0.1-SNAPSHOT since this is a fairly significant API change. Not sure if it warrants a bump to 2.1.0 or not. All APIs are backwards compatible to 2.0.0 with reasonable defaults, though behavior is changed to improve out-of-the-box performance.