### PR TITLE
added Resolve, which takes in one string via command line

### DIFF
--- a/src/main/java/com/bericotech/clavin/Resolve.java
+++ b/src/main/java/com/bericotech/clavin/Resolve.java
@@ -1,0 +1,71 @@
+package com.bericotech.clavin;
+
+import java.io.File;
+import java.util.List;
+
+import com.bericotech.clavin.resolver.ResolvedLocation;
+import com.bericotech.clavin.util.TextUtils;
+
+/*#####################################################################
+ * 
+ * CLAVIN (Cartographic Location And Vicinity INdexer)
+ * ---------------------------------------------------
+ * 
+ * Copyright (C) 2012-2013 Berico Technologies
+ * http://clavin.bericotechnologies.com
+ * 
+ * ====================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ * 
+ * ====================================================================
+ * 
+ * Resolve.java
+ * This one file was created by Daniel J. Dufour
+ *
+ *###################################################################*/
+
+/**
+ * Quick example showing how to use CLAVIN's capabilities.
+ * 
+ */
+public class Resolve {
+
+    /**
+     * Run this after installing & configuring CLAVIN to get a sense of
+     * how to use it.
+     * 
+     * @param args              not used
+     * @throws Exception
+     */
+    public static void main(String[] args) throws Exception {
+        System.out.println("Starting Resolve's main function");
+       
+        // Instantiate the CLAVIN GeoParser
+        GeoParser parser = GeoParserFactory.getDefault("./IndexDirectory");
+        
+        // Grab the contents of the text file as a String
+        String inputString = args[0];
+        
+        // Parse location names in the text into geographic entities
+        List<ResolvedLocation> resolvedLocations = parser.parse(inputString);
+        
+        // Display the ResolvedLocations found for the location names
+        for (ResolvedLocation resolvedLocation : resolvedLocations)
+            System.out.println(resolvedLocation);
+        
+        // And we're done...
+        System.out.println("\n\"That's all folks!\"");
+
+    }
+}


### PR DESCRIPTION
Short Story: I'd like to pass in a string to Clavin via command line, so I added a Java file that does it.  Use it if you like.

You can run the Resolve example by:

MAVEN_OPTS="-Xmx2g" mvn exec:java -Dexec.mainClass="com.bericotech.clavin.WorkflowDemo" -Dexec.args="WRITE YOUR STRING HERE"

Long Story: I'm working on a python project https://github.com/DanielJDufour/bkto and I want to use Clavin, so I'm building a python wrapper for Clavin (https://github.com/DanielJDufour/clavin-python).  The first step is to find a way to pass a string from python to Clavin/java, so I needed a java function that accepts a string from command line.  Also building a wrapper around Clavin-rest is complicated because my use of Tor to anonymize my web scraping forces all web traffic through Socks5 and blocks calls to localhost and clavin-rest server. Thanks. 