### PR TITLE
Use https instead of http to access maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@
             </snapshots>
             <id>central</id>
             <name>Maven Repository Switchboard</name>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
         </repository>
         <repository>
             <!-- This ugly beast (OpenNLP Dependency): jwnl:jwnl:1.3.3
@@ -383,7 +383,7 @@
             </snapshots>
             <id>central</id>
             <name>Maven Plugin Repository</name>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
As of January 15, 2020, The Central Repository no longer supports plain HTTP and requires that all requests to the repository to be encrypted over HTTPS.